### PR TITLE
Revert "init: don't set permissions for CID file"

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -1134,6 +1134,8 @@ service macloader /system/bin/macloader
     oneshot
 
 on property:init.svc.macloader=stopped
+    chown system root /data/.cid.info
+    chmod 0664 /data/.cid.info
     chown system root /data/.rev
     chmod 0664 /data/.rev
 


### PR DESCRIPTION
Original patch caused two problems with multiple klte variants
    -Could not rotate screen to landscape no matter what rotation options were selected
    -Could not turn screen on durring call regardless of proximity sensor

This reverts commit 56c41fc7736715c0326a39df4660bf3e0d47fcb8.

Change-Id: I2448cf36de5a428725ea54ae63829ec1baf14923